### PR TITLE
feat(escpos): enable ability to disable beeper, and support legacy raster print

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ const svg = receiptline.transform(doc, display);
 - `cutting` (for printer)
   - `false`: no paper cutting
   - `true`: paper cutting (default)
+- `beeper` (ESC/POS only)
+  - `false`: no beeper tone
+  - `true`: beeper on print (default)
+- `legacyImage` (ESC/POS only)
+  - `false`: uses newer `GS L` commands for image printing (default)
+  - `true`: uses obsolete `GS v 0 ` commands for image printing
 - `command`
   - `svg`: SVG (default)
   - `escpos`: ESC/POS (Epson)

--- a/lib/receiptline.js
+++ b/lib/receiptline.js
@@ -60,6 +60,8 @@ limitations under the License.
             gradient: 'gradient' in printer ? !!printer.gradient : true,
             gamma: printer.gamma || 1.8,
             threshold: printer.threshold || 128,
+            beeper: 'beeper' in printer ? !!printer.beeper : true,
+            legacyImage: !!printer.legacyImage,
             command: commands[printer.command] || commands.svg
         };
         // append commands to start printing
@@ -1531,6 +1533,8 @@ limitations under the License.
         gradient: true,
         gamma: 1.8,
         threshold: 128,
+        beeper: true,
+        legacyImage: false,
         // ruled line composition
         vrtable: {
             ' '    : { ' ' : ' ',    '\x90' : '\x90', '\x95' : '\x95', '\x9a' : '\x9a', '\x9b' : '\x9b', '\x9e' : '\x9e', '\x9f' : '\x9f' },
@@ -1591,7 +1595,9 @@ limitations under the License.
             this.gradient = printer.gradient;
             this.gamma = printer.gamma;
             this.threshold = printer.threshold;
-            return '\x1b@\x1da\x00\x1bM0\x1c(A' + $(2, 0, 48, 0) + '\x1b \x00\x1cS\x00\x00' + (this.spacing ? '\x1b2' : '\x1b3\x00') + '\x1b{' + $(this.upsideDown);
+            this.beeper = printer.beeper;
+            this.legacyImage = printer.legacyImage;
+            return '\x1b@\x1da\x00\x1bM0' + (this.beeper ? '\x1c(A' + $(2, 0, 48, 0) : '') + '\x1b \x00\x1cS\x00\x00' + (this.spacing ? '\x1b2' : '\x1b3\x00') + '\x1b{' + $(this.upsideDown);
         },
         // finish printing: GS r n
         close: function () {
@@ -1658,16 +1664,23 @@ limitations under the License.
         // image split size
         split: 512,
         // print image: GS 8 L p1 p2 p3 p4 m fn a bx by c xL xH yL yH d1 ... dk GS ( L pL pH m fn
+        // print image (legacy mode): GS v 0 m xL yL yH d1...dk
         image: function (image, align, left, width, right) {
             let r = this.upsideDown ? this.area(right, width, left) + this.align(2 - align) : this.area(left, width, right) + this.align(align);
             const img = PNG.sync.read(Buffer.from(image, 'base64'));
             const w = img.width;
             const d = Array(w).fill(0);
             let j = this.upsideDown ? img.data.length - 4 : 0;
+            const w8 = w + 7 >> 3
             for (let z = 0; z < img.height; z += this.split) {
                 const h = Math.min(this.split, img.height - z);
-                const l = (w + 7 >> 3) * h + 10;
-                r += '\x1d8L' + $(l & 255, l >> 8 & 255, l >> 16 & 255, l >> 24 & 255, 48, 112, 48, 1, 1, 49, w & 255, w >> 8 & 255, h & 255, h >> 8 & 255);
+                if (this.legacyImage) {
+                  r += '\x1dv0' + $(48, w8 & 255, w8 >> 8 & 255, h & 255, h >> 8 & 255);
+                }
+                else {
+                  const l = w8 * h + 10;
+                  r += '\x1d8L' + $(l & 255, l >> 8 & 255, l >> 16 & 255, l >> 24 & 255, 48, 112, 48, 1, 1, 49, w & 255, w >> 8 & 255, h & 255, h >> 8 & 255);
+                }
                 for (let y = 0; y < h; y++) {
                     let i = 0, e = 0;
                     for (let x = 0; x < w; x += 8) {
@@ -1693,7 +1706,7 @@ limitations under the License.
                         r += $(b);
                     }
                 }
-                r += '\x1d(L' + $(2, 0, 48, 50);
+                if (!this.legacyImage) r += '\x1d(L' + $(2, 0, 48, 50);
             }
             return r;
         },


### PR DESCRIPTION
Firstly, thanks so much for this amazing module! It truly is fantastic!

This pull request solves two issues I had.

1. I have a generic "ESCPOS Compatible" XPrinter, which would print the beeper command string at the top of the receipt. I've added an option to disable beeper control. The same issue was also present on a Star TSP143Lan when operating in ESCPOS mode.
2. Both the Star and the XPrinter were unable to print raster graphics at all, when using ESCPOS instead printing long strings of gibberish. The impact driver worked for printing graphics, however, the quality was not desirable. I've added support for the now obsolete command `GS v 0` which works very nicely on both of these printers to print great quality images and which is likely still on many printers still in circulation.

To be clear, the Star printer works fine in starline mode (I'm using printnode to submit the raw print commands/job to the printer).

I hope this request meets your approval!

Cheers again for an amazing library and toolset!

PS: I also have a typescript definition file for this module based on this pull request. If this is merged, I can submit another requests including it. I've listed it below for reference

```ts
export namespace receiptline {
  type Encoding = 'cp437' | 'cp852' | 'cp858' | 'cp860' | 'cp863' | 'cp865' | 'cp866' | 'cp1252' | 'cp932' | 'cp936' |
    'cp949' | 'cp950' | 'multilingual' | 'shiftjis' | 'gb18030' | 'ksc5601' | 'big5'
  type Command = 'svg' | 'escpos' | 'sii' | 'citizen' | 'fit' | 'impact' | 'impactb' | 'starsbcs' | 'starmbcs' |
    'starmbcs2' | 'starlinesbcs' | 'starlinembcs' | 'starlinembcs2' | 'emustarlinesbcs' | 'emustarlinembcs' |
    'emustarlinembcs2' | 'stargraphic'

  export interface PrinterSettings {
    cpl: number
    encoding: Encoding
    upsideDown: boolean
    spacing: boolean
    cutting: boolean
    gradient: boolean
    gamma: number
    threshold: number
    beeper: boolean
    legacyImage: boolean
    command: Command
  }

  export const transform: (document: string, printerSettings: Partial<PrinterSettings>) => string
}

export type PrinterSettings = receiptline.PrinterSettings
export default receiptline
```