### PR TITLE
docs: fix typo "Chinsese" -> "Chinese"

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ const svg = receiptline.transform(doc, display);
   - `starmbcs2`: StarPRNT (Chinese, Korean)
   - `starlinesbcs`: Star Line Mode (SBCS)
   - `starlinembcs`: Star Line Mode (Japanese)
-  - `starlinembcs2`: Star Line Mode (Chinsese, Korean)
+  - `starlinembcs2`: Star Line Mode (Chinese, Korean)
   - `emustarlinesbcs`: Command Emulator Star Line Mode (SBCS)
   - `emustarlinembcs`: Command Emulator Star Line Mode (Japanese)
-  - `emustarlinembcs2`: Command Emulator Star Line Mode (Chinsese, Korean)
+  - `emustarlinembcs2`: Command Emulator Star Line Mode (Chinese, Korean)
   - `stargraphic`: Star Graphic Mode (TSP100LAN)
   - `starimpact`: Star Mode on dot impact printers _Experimental_
   - `starimpact2`: Star Mode on dot impact printers (Font 5x9 2P-1) _Experimental_

--- a/lib/receiptline.d.ts
+++ b/lib/receiptline.d.ts
@@ -84,13 +84,13 @@ declare module 'receiptline' {
         starlinesbcs: BaseCommand;
         /** Star Line Mode (Japanese) */
         starlinembcs: BaseCommand;
-        /** Star Line Mode (Chinsese, Korean) */
+        /** Star Line Mode (Chinese, Korean) */
         starlinembcs2: BaseCommand;
         /** Command Emulator Star Line Mode (SBCS) */
         emustarlinesbcs: BaseCommand;
         /** Command Emulator Star Line Mode (Japanese) */
         emustarlinembcs: BaseCommand;
-        /** Command Emulator Star Line Mode (Chinsese, Korean) */
+        /** Command Emulator Star Line Mode (Chinese, Korean) */
         emustarlinembcs2: BaseCommand;
         /** Star Graphic Mode (TSP100LAN) */
         stargraphic: BaseCommand;


### PR DESCRIPTION
## Summary
Fixed misspelling of "Chinese" as "Chinsese" in CLI documentation and TypeScript type definitions.

## What changed
- README.md: 2 occurrences
- lib/receiptline.d.ts: 2 occurrences (JSDoc comments)

Closes #49